### PR TITLE
Enable backups

### DIFF
--- a/SupportFiles/DGCbackup.sh
+++ b/SupportFiles/DGCbackup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+#
+# Script to automate the backing-up of the Collibra environment
+# Note: MUST be installed on the Collibra console node
+#
+#################################################################
+ADMIN=${ADMIN:-Admin}
+PASSWD=${PASSWD:-UNDEF}
+S3BUCKET=${S3BUCKET:-UNDEF}
+SVCURL="http://127.0.0.1:4402"
+DATE=$(date "+%Y%m%d%H%M")
+
+function GetEnvId {
+   ENVIRONMENTJSON="$(
+         curl -skLu "${ADMIN}":"${PASSWD}" \
+           -X GET "${SVCURL}/rest/environment"
+      )"
+
+   echo "${ENVIRONMENTJSON}" | jq '.[0].id' | sed 's/"//g'
+}
+
+function MkBackup {
+
+   local BKUPJSON
+   BKUPJSON="{ \
+         \"name\": \"Backup-${DATE}\", \
+         \"description\": \"Cron-initiated backup for ${DATE}\", \
+         \"database\": \"dgc\", \
+         \"dgcBackupOptionSet\": [\"CUSTOMIZATIONS\"], \
+         \"repoBackupOptionSet\": [\"DATA\",\"HISTORY\",\"CONFIGURATION\"] \
+         } \
+      "
+
+   # Intiate backup job
+   BKUPJOB=$(
+         curl -skLu "${ADMIN}":"${PASSWD}" -X POST "${SVCURL}/rest/backup/${1}" \
+           -H 'cache-control: no-cache' -H 'content-type: application/json' \
+           -d "${BKUPJSON}"
+      )
+
+   BKUPJOBID=$( echo ${BKUPJOB} | jq .id | sed 's/"//g' )
+
+   # Wait for job to finish
+   while true
+   do
+      JOBSTATE=$( curl -skLu "${ADMIN}":"${PASSWD}" \
+              -X GET "${SVCURL}/rest/backup/${ENVMTID}/state" \
+              -H 'cache-control: no-cache' | \
+            jq .POST_PROCESSING.status | sed 's/"//g'
+         )
+      if [[ ${JOBSTATE} = COMPLETED ]]
+      then
+         echo "Backup done"
+         break
+      else
+         echo "Job is ${JOBSTATE}: waiting... "
+         sleep 10
+      fi
+   done
+}
+
+function FetchBkup {
+
+   # Download the backup file
+   printf "Downloading backup-ID %s... " "${BKUPJOBID}"
+   curl -skL -u "${ADMIN}":"${PASSWD}" \
+     -H "Content-Type:application/x-www-form-urlencoded" \
+     -X POST "${SVCURL}/rest/backup/file/${BKUPJOBID}" | \
+   aws s3 cp - "s3://${S3BUCKET}/DGC-Backup-${DATE}.zip" && \
+   echo "Success" || echo "Failed"
+
+}
+
+
+
+##################
+## Main Program ##
+##################
+
+# Need jq or this stuff blows up...
+if [[ $(rpm -q --quiet jq)$? -ne 0 ]]
+then
+   echo "Missing 'jq' utility. Aborting" > /dev/stderr
+   exit 1
+fi
+
+# Make sure we've got a password for our backup user
+if [[ ${PASSWD} = UNDEF ]]
+then
+   echo "No backup-admin password passed. Aborting" > /dev/stderr
+   exit 1
+fi
+
+# Make sure we have a destination
+if [[ ${S3BUCKET} = UNDEF ]]
+then
+   echo "No S3-destination specified. Aborting" > /dev/stderr
+   exit 1
+fi
+
+
+ENVMTID=$( GetEnvId )
+MkBackup "${ENVMTID}"
+FetchBkup

--- a/Templates/make_collibra_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra_EC2-standalone.tmplt.json
@@ -186,7 +186,8 @@
             "CollibraSoftwareDir",
             "CollibraDataDir",
             "CollibraConsolePassword",
-            "CollibraRepoPassword"
+            "CollibraRepoPassword",
+            "EpelRepoName"
           ]
         },
         {
@@ -405,6 +406,11 @@
       "Description": "Location where Collibra application-software should be rooted",
       "Type": "String"
     },
+    "EpelRepoName": {
+      "Default": "epel",
+      "Description": "Name of yum repository from which to pull extra RPMs.",
+      "Type": "String"
+    },
     "InstanceRoleName": {
       "Default": "",
       "Description": "(Optional) IAM instance role-name to use for signalling",
@@ -608,6 +614,19 @@
                       " curl -kL ",
                       { "Ref": "BackupScript" },
                       " -o /usr/local/sbin/collibra-bkup.sh\n"
+                    ]
+                  ]
+                }
+              },
+              "02-install-jq": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "yum --enablerepo=",
+                      { "Ref": "EpelRepoName" },
+                      " install -y jq\n",
+                      "\n"
                     ]
                   ]
                 }

--- a/Templates/make_collibra_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra_EC2-standalone.tmplt.json
@@ -80,6 +80,11 @@
         { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] }
       ]
     },
+    "UseGroupKeyfile": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "AdminPubkeyURL" }, "" ] }
+      ]
+    },
     "UseKeyPair": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "KeyPairName" }, "" ] }
@@ -147,7 +152,9 @@
             "AmiId",
             "InstanceType",
             "RootVolumeSize",
+            "ProvisionUser",
             "KeyPairName",
+            "AdminPubkeyURL",
             "InstanceRoleName",
             "InstanceRoleProfile",
             "SubnetId",
@@ -160,7 +167,7 @@
         },
         {
           "Label": {
-            "default": "Application Volume"
+            "default": "Application Storage"
           },
           "Parameters": [
             "AppVolumeDevice",
@@ -171,7 +178,32 @@
         },
         {
           "Label": {
-            "default": "EC2 Watchmaker Configuration"
+            "default": "Application Configuration"
+          },
+          "Parameters": [
+            "CollibraInstallerUrl",
+            "CollibraDgcComponent",
+            "CollibraSoftwareDir",
+            "CollibraDataDir",
+            "CollibraConsolePassword",
+            "CollibraRepoPassword"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Backup Configuration"
+          },
+          "Parameters": [
+            "BackupBucket",
+            "BackupSchedule",
+            "BackupScript",
+            "BackupUserName",
+            "BackupUserPassword"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Watchmaker Configuration"
           },
           "Parameters": [
             "PypiIndexUrl",
@@ -800,7 +832,13 @@
           "configSets": {
             "launch": [
               "setup",
-              "admkey-install",
+              {
+                "Fn::If": [
+                  "UseGroupKeyfile",
+                  "admkey-install",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
               {
                 "Fn::If": [
                   "InstallCloudWatchAgent",
@@ -829,7 +867,13 @@
             ],
             "update": [
               "setup",
-              "admkey-install",
+              {
+                "Fn::If": [
+                  "UseGroupKeyfile",
+                  "admkey-install",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
               {
                 "Fn::If": [
                   "InstallUpdates",

--- a/Templates/make_collibra_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra_EC2-standalone.tmplt.json
@@ -293,6 +293,27 @@
       "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is false",
       "Type": "String"
     },
+    "BackupBucket": {
+      "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set) Name of the S3 bucket in which to store Collibra backups",
+      "Type": "String"
+    },
+    "BackupSchedule": {
+      "Default": "45 0 * * *",
+      "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set) When to run backups via Linux cron system (use \"cronie\" cron-format)",
+      "Type": "String"
+    },
+    "BackupScript": {
+      "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set) S3-hosted location backup script",
+      "Type": "String"
+    },
+    "BackupUserName": {
+      "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set) User-name (inside the Collibra console) with permissions to run backup jobs",
+      "Type": "String"
+    },
+    "BackupUserPassword": {
+      "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set) Password of user (inside the Collibra console) with permissions to run backup jobs",
+      "Type": "String"
+    },
     "CfnBootstrapUtilsUrl": {
       "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
       "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
@@ -519,7 +540,7 @@
                 "owner": "root"
               },
               "/etc/cfn/scripts/admkey.sh": {
-              "content": {
+                "content": {
                   "Fn::Join": [
                     "",
                     [
@@ -543,6 +564,53 @@
               }
             }
           },
+          "configureBackups": {
+            "commands": {
+              "01-download-bkup-cron": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "install -Dbm 000755 -o root -g root /dev/null",
+                      " /usr/local/sbin/collibra-bkup.sh &&",
+                      " curl -kL ",
+                      { "Ref": "BackupScript" },
+                      " -o /usr/local/sbin/collibra-bkup.sh\n"
+                    ]
+                  ]
+                }
+              }
+            },
+            "files": {
+              "/etc/cron.d/backup-collibra": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "# Backup Collibra directly to S3\n",
+                      "#\n",
+                      "################################\n",
+                      "ADMIN=",
+                       { "Ref": "BackupUserName" },
+                       "\n",
+                      "PASSWD=",
+                       { "Ref": "BackupUserPassword" },
+                       "\n",
+                      "S3BUCKET=",
+                       { "Ref": "BackupBucket" },
+                       "\n",
+                       "\n",
+                      { "Ref": "BackupSchedule" },
+                       " root /usr/local/sbin/collibra-bkup.sh > /dev/null 2>&1\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              }
+            }
+          },
           "collibrainstall": {
             "commands": {
               "01-get-collibra-installer": {
@@ -554,7 +622,7 @@
                       " /etc/cfn/files/dgc-linux-installer.sh &&",
                       " aws s3 cp ",
                       { "Ref": "CollibraInstallerUrl" },
-                      " - > /etc/cfn/files/dgc-linux-installer.sh"
+                      " - > /etc/cfn/files/dgc-linux-installer.sh\n"
                     ]
                   ]
                 }
@@ -743,6 +811,13 @@
               "watchmaker-install",
               "watchmaker-launch",
               "collibrainstall",
+              {
+                "Fn::If": [
+                  "IsConsoleServer",
+                  "configureBackups",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
               "finalize",
               {
                 "Fn::If": [
@@ -765,6 +840,13 @@
               "watchmaker-install",
               "watchmaker-update",
               "collibrainstall",
+              {
+                "Fn::If": [
+                  "IsConsoleServer",
+                  "configureBackups",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
               "finalize",
               {
                 "Fn::If": [
@@ -1085,6 +1167,15 @@
                        "\n",
                       "DGC_REPO_PASSWD=",
                        { "Ref": "CollibraRepoPassword" },
+                       "\n",
+                      "DGC_BACKUP_SCHEDULE=",
+                       { "Ref": "BackupSchedule" },
+                       "\n",
+                      "DGC_BACKUP_USER_NAME=",
+                       { "Ref": "BackupUserName" },
+                       "\n",
+                      "DGC_BACKUP_USER_PASSWORD=",
+                       { "Ref": "BackupUserPassword" },
                        "\n"
                     ]
                   ]

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes.groovy
@@ -62,6 +62,7 @@ pipeline {
          string(name: 'BackupScript', description: 'URL to the backup script invoked by cron')
          string(name: 'BackupUserName', defaultValue: 'Admin', description: 'Collibra-console user-name to run backups under')
          string(name: 'BackupUserPassword', description: 'Password of Collibra-console user-name to run backups under')
+         string(name: 'EpelRepoName', defaultValue: 'epel', description: 'Name of yum repository from which to pull extra RPMs')
     }
 
     stages {
@@ -153,6 +154,10 @@ pipeline {
                              {
                                  "ParameterKey": "CollibraSoftwareDir",
                                  "ParameterValue": "${env.CollibraSoftwareDir}"
+                             },
+                             {
+                                 "ParameterKey": "EpelRepoName",
+                                 "ParameterValue": "${env.EpelRepoName}"
                              },
                              {
                                  "ParameterKey": "InstanceRoleName",

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes.groovy
@@ -19,12 +19,11 @@ pipeline {
          string(name: 'AwsRegion', defaultValue: 'us-east-1', description: 'Amazon region to deploy resources into')
          string(name: 'AwsCred', description: 'Jenkins-stored AWS credential with which to execute cloud-layer commands')
          string(name: 'GitCred', description: 'Jenkins-stored Git credential with which to execute git commands')
-         string(name: 'GitProjUrl', description: 'SSH URL from which to download the Sonarqube git project')
-         string(name: 'GitProjBranch', description: 'Project-branch to use from the Sonarqube git project')
+         string(name: 'GitProjUrl', description: 'SSH URL from which to download the Collibra git project')
+         string(name: 'GitProjBranch', description: 'Project-branch to use from the Collibra git project')
          string(name: 'CfnStackRoot', description: 'Unique token to prepend to all stack-element names')
          string(name: 'TemplateUrl', description: 'S3-hosted URL for the EC2 template file')
          string(name: 'AdminPubkeyURL', defaultValue: '', description: '(Optional) URL of file containing admin groups SSH public-keys')
-
          string(name: 'AmiId', description: 'ID of the AMI to launch')
          string(name: 'AppVolumeDevice', defaultValue: 'false', description: 'Whether to attach a secondary volume to host application contents')
          string(name: 'AppVolumeMountPath', defaultValue: '/opt/collibra', description: 'Filesystem path to mount the extra app volume. Ignored if "AppVolumeDevice" is false')
@@ -35,7 +34,6 @@ pipeline {
          string(name: 'CloudWatchAgentUrl', defaultValue: 's3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip', description: '(Optional) S3 URL to CloudWatch Agent installer')
          string(name: 'CollibraConsolePassword', description: 'Password to link the Collibra DGC and Console services')
          string(name: 'CollibraDataDir', defaultValue: '/opt/collibra/data', description: 'Location for storage of Collibra application-data')
-         string(name: 'CollibraDgcComponent', description: 'Which Collibra element to deploy (CONSOLE|DGC|REPOSITORY|AGENT|JOBSERVER)')
          string(name: 'CollibraInstallerUrl', description: 'URL from which to download the Collibra installer SHAR-file')
          string(name: 'CollibraRepoPassword', description: 'Password to use for accessing the Repository database')
          string(name: 'CollibraSoftwareDir', defaultValue: '/opt/collibra/software', description: 'Location for storage of Collibra application-software')
@@ -59,6 +57,11 @@ pipeline {
          string(name: 'WatchmakerConfig', description: '(Optional) Path to a Watchmaker config file.  The config file path can be a remote source (i.e. http[s]://, s3://) or local directory (i.e. file://)')
          string(name: 'WatchmakerEnvironment', defaultValue: 'dev', description: 'What build environment to deploy instance to')
          string(name: 'WatchmakerOuPath', description: 'OU-path in which to create Active Directory computer object')
+         string(name: 'BackupBucket', description: 'S3 Bucket-name in which to store DGC backups')
+         string(name: 'BackupSchedule', defaultValue: '45 0 * * *', description: 'When, in cronie-format, to run backups')
+         string(name: 'BackupScript', description: 'URL to the backup script invoked by cron')
+         string(name: 'BackupUserName', defaultValue: 'Admin', description: 'Collibra-console user-name to run backups under')
+         string(name: 'BackupUserPassword', description: 'Password of Collibra-console user-name to run backups under')
     }
 
     stages {
@@ -71,6 +74,26 @@ pipeline {
                 writeFile file: 'EC2.parms.json',
                    text: /
                          [
+                             {
+                                 "ParameterKey": "BackupBucket",
+                                 "ParameterValue": "${env.BackupBucket}"
+                             },
+                             {
+                                 "ParameterKey": "BackupSchedule",
+                                 "ParameterValue": "${env.BackupSchedule}"
+                             },
+                             {
+                                 "ParameterKey": "BackupScript",
+                                 "ParameterValue": "${env.BackupScript}"
+                             },
+                             {
+                                 "ParameterKey": "BackupUserName",
+                                 "ParameterValue": "${env.BackupUserName}"
+                             },
+                             {
+                                 "ParameterKey": "BackupUserPassword",
+                                 "ParameterValue": "${env.BackupUserPassword}"
+                             },
                              {
                                  "ParameterKey": "AdminPubkeyURL",
                                  "ParameterValue": "${env.AdminPubkeyURL}"

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes.groovy
@@ -46,7 +46,7 @@ pipeline {
          string(name: 'NoUpdates', defaultValue: 'false', description: 'Whether to prevent updating all installed RPMs as part of build process')
          string(name: 'PrivateIp', description: 'If set to a dotted-quad, attempt to set the requested private IP address on instance')
          string(name: 'ProvisionUser', defaultValue: 'ec2-user', description: 'Default login-user to create upon instance-launch')
-         string(name: 'PypiIndexUrl', description: 'Source from which to pull Pypi packages')
+         string(name: 'PypiIndexUrl', defaultValue: 'https://pypi.org/simple', description: 'Source from which to pull Pypi packages')
          string(name: 'RootVolumeSize', defaultValue: '20', description: 'How big to make the root EBS volume (ensure value specified is at least as big as the AMI-default)')
          string(name: 'SecurityGroupIds', description: 'Comma-separated list of EC2 security-groups to apply to the instance')
          string(name: 'SubnetId', description: 'Subnet-ID to deploy EC2 instance into')

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes_R53.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes_R53.groovy
@@ -65,6 +65,7 @@ pipeline {
          string(name: 'BackupScript', description: 'URL to the backup script invoked by cron')
          string(name: 'BackupUserName', defaultValue: 'Admin', description: 'Collibra-console user-name to run backups under')
          string(name: 'BackupUserPassword', description: 'Password of Collibra-console user-name to run backups under')
+         string(name: 'EpelRepoName', defaultValue: 'epel', description: 'Name of yum repository from which to pull extra RPMs')
     }
 
     stages {
@@ -156,6 +157,10 @@ pipeline {
                              {
                                  "ParameterKey": "CollibraSoftwareDir",
                                  "ParameterValue": "${env.CollibraSoftwareDir}"
+                             },
+                             {
+                                 "ParameterKey": "EpelRepoName",
+                                 "ParameterValue": "${env.EpelRepoName}"
                              },
                              {
                                  "ParameterKey": "InstanceRoleName",

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes_R53.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes_R53.groovy
@@ -60,6 +60,11 @@ pipeline {
          string(name: 'WatchmakerConfig', description: '(Optional) Path to a Watchmaker config file.  The config file path can be a remote source (i.e. http[s]://, s3://) or local directory (i.e. file://)')
          string(name: 'WatchmakerEnvironment', defaultValue: 'dev', description: 'What build environment to deploy instance to')
          string(name: 'WatchmakerOuPath', description: 'OU-path in which to create Active Directory computer object')
+         string(name: 'BackupBucket', description: 'S3 Bucket-name in which to store DGC backups')
+         string(name: 'BackupSchedule', defaultValue: '45 0 * * *', description: 'When, in cronie-format, to run backups')
+         string(name: 'BackupScript', description: 'URL to the backup script invoked by cron')
+         string(name: 'BackupUserName', defaultValue: 'Admin', description: 'Collibra-console user-name to run backups under')
+         string(name: 'BackupUserPassword', description: 'Password of Collibra-console user-name to run backups under')
     }
 
     stages {
@@ -72,6 +77,26 @@ pipeline {
                 writeFile file: 'EC2.parms.json',
                    text: /
                          [
+                             {
+                                 "ParameterKey": "BackupBucket",
+                                 "ParameterValue": "${env.BackupBucket}"
+                             },
+                             {
+                                 "ParameterKey": "BackupSchedule",
+                                 "ParameterValue": "${env.BackupSchedule}"
+                             },
+                             {
+                                 "ParameterKey": "BackupScript",
+                                 "ParameterValue": "${env.BackupScript}"
+                             },
+                             {
+                                 "ParameterKey": "BackupUserName",
+                                 "ParameterValue": "${env.BackupUserName}"
+                             },
+                             {
+                                 "ParameterKey": "BackupUserPassword",
+                                 "ParameterValue": "${env.BackupUserPassword}"
+                             },
                              {
                                  "ParameterKey": "AdminPubkeyURL",
                                  "ParameterValue": "${env.AdminPubkeyURL}"

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes_R53.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes_R53.groovy
@@ -48,7 +48,7 @@ pipeline {
          string(name: 'NoUpdates', defaultValue: 'false', description: 'Whether to prevent updating all installed RPMs as part of build process')
          string(name: 'PrivateIp', description: 'If set to a dotted-quad, attempt to set the requested private IP address on instance')
          string(name: 'ProvisionUser', defaultValue: 'ec2-user', description: 'Default login-user to create upon instance-launch')
-         string(name: 'PypiIndexUrl', description: 'Source from which to pull Pypi packages')
+         string(name: 'PypiIndexUrl', defaultValue: 'https://pypi.org/simple', description: 'Source from which to pull Pypi packages')
          string(name: 'R53ZoneId', description: 'Route53 ZoneId to create proxy-alias DNS record')
          string(name: 'RootVolumeSize', defaultValue: '20', description: 'How big to make the root EBS volume (ensure value specified is at least as big as the AMI-default)')
          string(name: 'SecurityGroupIds', description: 'Comma-separated list of EC2 security-groups to apply to the instance')


### PR DESCRIPTION
#### Description:

Updates EC2 templates (and associated Jenkins pipelines)  to enable DGC backups when template launches a node of type `CONSOLE`.

#### Rationale:

Application doesn't come with a native backup utility or method for backing up to S3. This update fills that gap.
