### PR TITLE
Closes #12:

### DIFF
--- a/Templates/make_collibra_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra_EC2-standalone.tmplt.json
@@ -1303,6 +1303,7 @@
                     [
                       "watchmaker --log-level debug",
                       " --log-dir /var/log/watchmaker",
+                      " --exclude-states scap*scan",
                       " --no-reboot",
                       {
                         "Fn::If": [
@@ -1403,6 +1404,9 @@
                     ]
                   ]
                 }
+              },
+              "15-salt-nofips": {
+                "command": "salt-call --local ash.fips_disable"
               }
             }
           },

--- a/Templates/make_collibra_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra_EC2-standalone.tmplt.json
@@ -657,7 +657,7 @@
                   ]
                 },
                 "group": "root",
-                "mode": "000700",
+                "mode": "000644",
                 "owner": "root"
               }
             }


### PR DESCRIPTION
#### Description:

Adds a secondary salt-run to disable FIPS mode

#### Rationale:

Having OS running in FIPS mode appears to interfere with a couple components of Collibra &mdash the most immediately-obvious of which was inability to set up new users due to inability to email password-reset links.

Note: Collibra SMTP connector apparently does not use a FIPS-compatible STARTTLS method. Disabling FIPS-mode allows SMTP relaying via TLS-enabled relays (i.e., AWS's Simple Email Service) to function.