### PR TITLE
Fixes #20. Changes pipeline parameter desciription text:

### DIFF
--- a/TestStuff/Jenkins/standalone-CFn-Elb.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-Elb.groovy
@@ -29,7 +29,7 @@ pipeline {
          string(name: 'ElbShortName', description: 'A short, human-friendly label to assign to the ELB (no capital letters)')
          string(name: 'CollibraInstanceId', defaultValue: '', description: 'ID of the EC2-instance this template should create a proxy for (typically left blank)')
          string(name: 'CollibraListenPort', defaultValue: '443', description: 'Public-facing TCP Port number on which the ELB listens for requests to proxy')
-         string(name: 'HaSubnets', description: 'IDs of public-facing subnets in which to create service-listeners')
+         string(name: 'HaSubnets', description: 'Provide a comma-separated list of user-facing subnet IDs in which to create service-listeners')
          string(name: 'CollibraListenerCert', description: 'AWS Certificate Manager Certificate ID to bind to SSL listener')
          string(name: 'SecurityGroupIds', description: 'List of security groups to apply to the ELB')
          string(name: 'TargetVPC', description: 'ID of the VPC to deploy cluster nodes into')


### PR DESCRIPTION
* From: 'IDs of public-facing subnets in which to create service-listeners'
* To: 'Provide a comma-separated list of user-facing subnet IDs in which to create service-listeners'
