### PR TITLE
Get rid of now-extraneous components:

### DIFF
--- a/Templates/make_collibra-esb_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-esb_EC2-standalone.tmplt.json
@@ -343,16 +343,6 @@
       "Description": "(Optional) Public/private key pairs allow you to securely connect to your instance after it launches",
       "Type": "String"
     },
-    "MuleConnectorZipUri": {
-      "AllowedPattern": "^http[s]?://.*$",
-      "Description": "URL to the curl-fetchable Collibra DGC Connector software for Mule ESB",
-      "Type": "String"
-    },
-    "MuleDomainZipUri": {
-      "AllowedPattern": "^http[s]?://.*$",
-      "Description": "URL to the curl-fetchable Collibra Domain software for Mule ESB",
-      "Type": "String"
-    },
     "MuleLicenseUri": {
       "AllowedPattern": "^http[s]?://.*$",
       "Description": "URL to the curl-fetchable Mule ESB software-license.",
@@ -738,31 +728,7 @@
                   ]
                 }
               },
-              "03-get-muleDomain": {
-                "command": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "su -s /bin/bash - mule -c \"cd domains && curl -OkL ",
-                        { "Ref": "MuleDomainZipUri" },
-                        "\"\n"
-                    ]
-                  ]
-                }
-              },
-              "04-get-muleConnector": {
-                "command": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "su -s /bin/bash - mule -c \"cd apps && curl -OkL ",
-                        { "Ref": "MuleConnectorZipUri" },
-                        "\"\n"
-                    ]
-                  ]
-                }
-              },
-              "05-get-muleLicense": {
+              "03-get-muleLicense": {
                 "command": {
                   "Fn::Join": [
                     "",
@@ -774,7 +740,7 @@
                   ]
                 }
               },
-              "06-install-muleLicense": {
+              "04-install-muleLicense": {
                 "command": {
                   "Fn::Join": [
                     "",
@@ -785,10 +751,10 @@
                   ]
                 }
               },
-              "07-firewalld-cbt": {
+              "05-firewalld-cbt": {
                 "command": "firewall-offline-cmd --add-port=7777/tcp"
               },
-              "07-firewalld-mdns": {
+              "05-firewalld-mdns": {
                 "command": "firewall-offline-cmd --add-service=mdns"
               },
               "10-daemon-reload": {
@@ -797,7 +763,7 @@
               "11-enable-esb": {
                 "command": "systemctl enable mule-esb.service"
               },
-              "12-enable-esb": {
+              "12-start-esb": {
                 "command": "systemctl start mule-esb.service"
               }
             },
@@ -1018,12 +984,6 @@
                        "\n",
                       "MULE_LICENSE=",
                        { "Ref": "MuleLicenseUri" },
-                       "\n",
-                      "MULE_DOMAIN_SOFTWARE=",
-                       { "Ref": "MuleDomainZipUri" },
-                       "\n",
-                      "MULE_CONNECTOR_SOFTWARE=",
-                       { "Ref": "MuleConnectorZipUri" },
                        "\n",
                       "MULE_BACKUP_SCHEDULE=",
                        { "Ref": "BackupSchedule" },

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb.groovy
@@ -40,8 +40,6 @@ pipeline {
          string(name: 'KeyPairName', description: 'Registered SSH key used to provision the node')
          string(name: 'MuleUri', description: 'A curl-fetchable URL for the Mule ESB software' )
          string(name: 'MuleLicenseUri', description: 'A curl-fetchable URL for the Mule ESB license file')
-         string(name: 'MuleDomainZipUri', description: 'A curl-fetchable URL for the Mule ESB domain ZIP-file')
-         string(name: 'MuleConnectorZipUri', description: 'A curl-fetchable URL for the Collibra Connector ZIP-file')
          string(name: 'NoPublicIp', defaultValue: 'true', description: 'Whether to set a public IP ("true" means "dont")')
          string(name: 'NoReboot', defaultValue: 'false', description: 'Whether to prevent the instance from rebooting at completion of build')
          string(name: 'NoUpdates', defaultValue: 'false', description: 'Whether to prevent updating all installed RPMs as part of build process')
@@ -129,14 +127,6 @@ pipeline {
                              {
                                  "ParameterKey": "KeyPairName",
                                  "ParameterValue": "${env.KeyPairName}"
-                             },
-                             {
-                                 "ParameterKey": "MuleConnectorZipUri",
-                                 "ParameterValue": "${env.MuleConnectorZipUri}"
-                             },
-                             {
-                                 "ParameterKey": "MuleDomainZipUri",
-                                 "ParameterValue": "${env.MuleDomainZipUri}"
                              },
                              {
                                  "ParameterKey": "MuleLicenseUri",

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb_R53.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb_R53.groovy
@@ -40,8 +40,6 @@ pipeline {
          string(name: 'KeyPairName', description: 'Registered SSH key used to provision the node')
          string(name: 'MuleUri', description: 'A curl-fetchable URL for the Mule ESB software' )
          string(name: 'MuleLicenseUri', description: 'A curl-fetchable URL for the Mule ESB license file')
-         string(name: 'MuleDomainZipUri', description: 'A curl-fetchable URL for the Mule ESB domain ZIP-file')
-         string(name: 'MuleConnectorZipUri', description: 'A curl-fetchable URL for the Collibra Connector ZIP-file')
          string(name: 'NoPublicIp', defaultValue: 'true', description: 'Whether to set a public IP ("true" means "dont")')
          string(name: 'NoReboot', defaultValue: 'false', description: 'Whether to prevent the instance from rebooting at completion of build')
          string(name: 'NoUpdates', defaultValue: 'false', description: 'Whether to prevent updating all installed RPMs as part of build process')
@@ -131,14 +129,6 @@ pipeline {
                              {
                                  "ParameterKey": "KeyPairName",
                                  "ParameterValue": "${env.KeyPairName}"
-                             },
-                             {
-                                 "ParameterKey": "MuleConnectorZipUri",
-                                 "ParameterValue": "${env.MuleConnectorZipUri}"
-                             },
-                             {
-                                 "ParameterKey": "MuleDomainZipUri",
-                                 "ParameterValue": "${env.MuleDomainZipUri}"
                              },
                              {
                                  "ParameterKey": "MuleLicenseUri",


### PR DESCRIPTION
Closes #18. Nuke all references to:
* "MuleConnectorZipUri"
* "MuleDomainZipUri"
In templates and Jenkins pipelines