### PR TITLE
Add "internet-facing" toggle

### DIFF
--- a/Templates/make_collibra_ELBv2.tmplt.json
+++ b/Templates/make_collibra_ELBv2.tmplt.json
@@ -1,6 +1,14 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Conditions": {
+        "HasIgw": {
+            "Fn::Equals": [
+                {
+                    "Ref": "PublicFacing"
+                },
+                "true"
+            ]
+        },
         "SetInstanceId": {
             "Fn::Not": [
                 {
@@ -54,6 +62,7 @@
                     "Parameters": [
                         "ProxyPrettyName",
                         "CollibraListenPort",
+                        "PublicFacing",
                         "TargetVPC",
                         "SecurityGroupIds",
                         "CertHostingService",
@@ -191,6 +200,15 @@
             "Description": "A short, human-friendly label to assign to the ELB (no capital letters).",
             "Type": "String"
         },
+        "PublicFacing": {
+            "AllowedValues": [
+                "false",
+                "true"
+            ],
+            "Default": "false",
+            "Description": "(Boolean) Whether target subnets have an IGW",
+            "Type": "String"
+        },
         "SecurityGroupIds": {
             "Description": "List of security groups to apply to the ELB.",
             "Type": "List<AWS::EC2::SecurityGroup::Id>"
@@ -288,7 +306,13 @@
                         }
                     ]
                 },
-                "Scheme": "internet-facing",
+                "Scheme": {
+                    "Fn::If": [
+                        "HasIgw",
+                        "internet-facing",
+                        "internal"
+                    ]
+                },
                 "SecurityGroups": {
                     "Ref": "SecurityGroupIds"
                 },

--- a/TestStuff/Jenkins/standalone-CFn-Elb.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-Elb.groovy
@@ -34,6 +34,7 @@ pipeline {
          string(name: 'CollibraListenerCert', description: 'AWS Certificate Manager Certificate ID to bind to SSL listener')
          string(name: 'SecurityGroupIds', description: 'List of security groups to apply to the ELB')
          string(name: 'TargetVPC', description: 'ID of the VPC to deploy cluster nodes into')
+         string(name: 'PublicFacing', defaultValue: 'false', description: 'Whether or not proxy is "internet-facing"')
     }
 
     stages {
@@ -77,6 +78,10 @@ pipeline {
                            {
                                "ParameterKey": "ProxyPrettyName",
                                "ParameterValue": "${env.ElbShortName}"
+                           },
+                           {
+                               "ParameterKey": "PublicFacing",
+                               "ParameterValue": "${env.PublicFacing}"
                            },
                            {
                                "ParameterKey": "SecurityGroupIds",


### PR DESCRIPTION
Add logic to allow toggling of ELB deployment-scheme (`internal` vs. `internet-facing`)