### PR TITLE
Fix SCM declares

### DIFF
--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes-dgc.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes-dgc.groovy
@@ -60,9 +60,12 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
+
+                // Create parameter file to be used with stack-create //
                 writeFile file: 'EC2.parms.json',
                    text: /
                          [
@@ -212,6 +215,8 @@ pipeline {
                              }
                          ]
                    /
+
+                // Clean up stale AWS resources //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes-dgc_R53.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes-dgc_R53.groovy
@@ -65,12 +65,29 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
-                git branch: "${GitProjBranch}",
-                    credentialsId: "${GitCred}",
-                    url: "${GitProjUrl}"
+
+                // More-pedantic SCM declaration to allow use with tags //
+                checkout scm: [
+                        $class: 'GitSCM',
+                        userRemoteConfigs: [
+                            [
+                                url: "${GitProjUrl}",
+                                credentialsId: "${GitCred}"
+                            ]
+                        ],
+                        branches: [
+                            [
+                                name: "${GitProjBranch}"
+                            ]
+                        ]
+                    ],
+                    poll: false
+
+                // Create parameter file to be used with stack-create //
                 writeFile file: 'EC2.parms.json',
                    text: /
                          [
@@ -220,6 +237,8 @@ pipeline {
                              }
                          ]
                    /
+
+                // Clean up stale AWS resources //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb.groovy
@@ -51,9 +51,12 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
+
+                // Create parameter file to be used with stack-create //
                 writeFile file: 'EC2.parms.json',
                    text: /
                          [
@@ -167,6 +170,8 @@ pipeline {
                              }
                          ]
                    /
+
+                // Clean up stale AWS resources //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities

--- a/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb_R53.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-EC2nodes-esb_R53.groovy
@@ -56,12 +56,29 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
-                git branch: "${GitProjBranch}",
-                    credentialsId: "${GitCred}",
-                    url: "${GitProjUrl}"
+
+                // More-pedantic SCM declaration to allow use with tags //
+                checkout scm: [
+                        $class: 'GitSCM',
+                        userRemoteConfigs: [
+                            [
+                                url: "${GitProjUrl}",
+                                credentialsId: "${GitCred}"
+                            ]
+                        ],
+                        branches: [
+                            [
+                                name: "${GitProjBranch}"
+                            ]
+                        ]
+                    ],
+                    poll: false
+
+                // Create parameter file to be used with stack-create //
                 writeFile file: 'EC2.parms.json',
                    text: /
                          [
@@ -175,6 +192,8 @@ pipeline {
                              }
                          ]
                    /
+
+                // Clean up stale AWS resources //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities

--- a/TestStuff/Jenkins/standalone-CFn-Elb.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-Elb.groovy
@@ -38,7 +38,7 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
                 // Make sure work-directory is clean //
                 deleteDir()

--- a/TestStuff/Jenkins/standalone-CFn-IAM.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-IAM.groovy
@@ -30,12 +30,29 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
-                git branch: "${GitProjBranch}",
-                    credentialsId: "${GitCred}",
-                    url: "${GitProjUrl}"
+
+                // More-pedantic SCM declaration to allow use with tags //
+                checkout scm: [
+                        $class: 'GitSCM',
+                        userRemoteConfigs: [
+                            [
+                                url: "${GitProjUrl}",
+                                credentialsId: "${GitCred}"
+                            ]
+                        ],
+                        branches: [
+                            [
+                                name: "${GitProjBranch}"
+                            ]
+                        ]
+                    ],
+                    poll: false
+
+                // Create parameter file to be used with stack-create //
                 writeFile file: 'IAM.parms.json',
                    text: /
                          [
@@ -57,6 +74,8 @@ pipeline {
                              }
                          ]
                    /
+
+                // Clean up stale AWS resources //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities

--- a/TestStuff/Jenkins/standalone-CFn-S3.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-S3.groovy
@@ -35,10 +35,27 @@ pipeline {
     stages {
         stage ('Cleanup Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
-                git branch: "${GitProjBranch}",
-                    credentialsId: "${GitCred}",
-                    url: "${GitProjUrl}"
+
+                // More-pedantic SCM declaration to allow use with tags //
+                checkout scm: [
+                        $class: 'GitSCM',
+                        userRemoteConfigs: [
+                            [
+                                url: "${GitProjUrl}",
+                                credentialsId: "${GitCred}"
+                            ]
+                        ],
+                        branches: [
+                            [
+                                name: "${GitProjBranch}"
+                            ]
+                        ]
+                    ],
+                    poll: false
+
+                // Create parameter file to be used with stack-create //
                 writeFile file: 'S3bucket.parms.json',
                    text: /
                          [
@@ -68,6 +85,8 @@ pipeline {
                              }
                          ]
                    /
+
+                // Clean up stale AWS resources //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities

--- a/TestStuff/Jenkins/standalone-CFn-S3.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-S3.groovy
@@ -33,7 +33,7 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
                 // Make sure work-directory is clean //
                 deleteDir()

--- a/TestStuff/Jenkins/standalone-CFn-SecGrps.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-SecGrps.groovy
@@ -27,7 +27,7 @@ pipeline {
     }
 
     stages {
-        stage ('Cleanup Work Environment') {
+        stage ('Prep Work Environment') {
             steps {
                 // Make sure work-directory is clean //
                 deleteDir()

--- a/TestStuff/Jenkins/standalone-CFn-SecGrps.groovy
+++ b/TestStuff/Jenkins/standalone-CFn-SecGrps.groovy
@@ -29,10 +29,28 @@ pipeline {
     stages {
         stage ('Cleanup Work Environment') {
             steps {
+                // Make sure work-directory is clean //
                 deleteDir()
-                git branch: "${GitProjBranch}",
-                    credentialsId: "${GitCred}",
-                    url: "${GitProjUrl}"
+
+                // More-pedantic SCM declaration to allow use with tags //
+                checkout scm: [
+                        $class: 'GitSCM',
+                        userRemoteConfigs: [
+                            [
+                                url: "${GitProjUrl}",
+                                credentialsId: "${GitCred}"
+                            ]
+                        ],
+                        branches: [
+                            [
+                                name: "${GitProjBranch}"
+                            ]
+                        ]
+                    ],
+                    poll: false
+
+                // Create parameter file to be used with stack-create //
+
                 writeFile file: 'SG.parms.json',
                    text: /
                          [
@@ -42,6 +60,7 @@ pipeline {
                              }
                          ]
                    /
+                // Create parameter file to be used with stack-create //
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''#!/bin/bash
                        # For compatibility with ancient AWS CLI utilities


### PR DESCRIPTION
#### Description:

- Fixes how how git clones are executed using the Jenkins DSL's git SCM module-class.

#### Rationale:

- Previous method only supported cloning from branches
- Replacement method adds support for cloning from commit-tags