### PR TITLE
Remove no-longer-valid 'repoBackupOptionSet', "CONFIGURATION"

### DIFF
--- a/SupportFiles/DGCbackup.sh
+++ b/SupportFiles/DGCbackup.sh
@@ -29,7 +29,7 @@ function MkBackup {
          \"description\": \"Cron-initiated backup for ${DATE}\", \
          \"database\": \"dgc\", \
          \"dgcBackupOptionSet\": [\"CUSTOMIZATIONS\"], \
-         \"repoBackupOptionSet\": [\"DATA\",\"HISTORY\",\"CONFIGURATION\"] \
+         \"repoBackupOptionSet\": [\"DATA\",\"HISTORY\"] \
          } \
       "
 


### PR DESCRIPTION
#### Description:

With update to 5.7, "CONFIGURATION" backup parameter no longer valid. API returns error

~~~
{
    "statusCode": 400,
    "titleMessage": "Bad' 'Request",
    "helpMessage": "Please' correct the input 'object",
    "userMessage": "There was an error while processing JSON content. The original message was: \"Cannot deserialize value of type 'com.collibra.console.api.v1.model.backup.RepositoryBackupOption' from String 'CONFIGURATION': value not one of declared Enum instance names: [DATA,HISTORY]\""
}
~~~
When requesting "CONFIGURATION"