### PR TITLE
Fix for APIv2 compatibility:

### DIFF
--- a/SupportFiles/DGCbackup.sh
+++ b/SupportFiles/DGCbackup.sh
@@ -28,7 +28,7 @@ function MkBackup {
          \"name\": \"Backup-${DATE}\", \
          \"description\": \"Cron-initiated backup for ${DATE}\", \
          \"database\": \"dgc\", \
-         \"dgcBackupOptionSet\": [\"CUSTOMIZATIONS\"], \
+         \"dgcBackupOptionSet\": [\"CUSTOMIZATIONS\",\"CONFIGURATION\"], \
          \"repoBackupOptionSet\": [\"DATA\",\"HISTORY\"] \
          } \
       "


### PR DESCRIPTION
Move 'CONFIGURATION' from 'repoBackupOptionSet' option-list to
the 'dgcBackupOptionSet' option-list

#### Description:

Restores full functionality to backup script: adds back capture `CONFIGURATION` data-set as part of backups

#### Rationale:

With Collibra 5.7.x, the `CONFIGURATION` data-set was moved from the `repoBackupOptionSet` to the `dgcBackupOptionSet` backup target-list.

#### References:

See vendor [backup API document](https://productresources.collibra.com/docs/install/5.7/#Console/Backups/ta_backup-and-download-with-rest-api.htm).