### PR TITLE
Miscellaneous updates:

### DIFF
--- a/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
@@ -175,6 +175,18 @@
                 }
             ]
         },
+        "UseEpelRepo": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "EpelRepoName"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseGroupKeyfile": {
             "Fn::Not": [
                 {
@@ -247,6 +259,11 @@
                 "FwPort": "4404",
                 "SystemdSvc": "collibra-agent"
             },
+            "MONITORING": {
+                "AddlFwPort": "",
+                "FwPort": "4407",
+                "SystemdSvc": "collibra-agent"
+            },
             "REPOSITORY": {
                 "AddlFwPort": "",
                 "FwPort": "4403",
@@ -271,6 +288,15 @@
             "c5.xlarge": {
                 "SupportsNvme": "true"
             },
+            "c5.2xlarge": {
+                "SupportsNvme": "true"
+            },
+            "c5.4xlarge": {
+                "SupportsNvme": "true"
+            },
+            "c5.8xlarge": {
+                "SupportsNvme": "true"
+            },
             "m4.large": {
                 "SupportsNvme": "false"
             },
@@ -281,6 +307,30 @@
                 "SupportsNvme": "true"
             },
             "m5.xlarge": {
+                "SupportsNvme": "true"
+            },
+            "m5.2large": {
+                "SupportsNvme": "true"
+            },
+            "m5.4xlarge": {
+                "SupportsNvme": "true"
+            },
+            "m5.8xlarge": {
+                "SupportsNvme": "true"
+            },
+            "r5.large": {
+                "SupportsNvme": "true"
+            },
+            "r5.xlarge": {
+                "SupportsNvme": "true"
+            },
+            "r5.2large": {
+                "SupportsNvme": "true"
+            },
+            "r5.4xlarge": {
+                "SupportsNvme": "true"
+            },
+            "r5.8xlarge": {
                 "SupportsNvme": "true"
             },
             "t2.large": {
@@ -297,6 +347,21 @@
             },
             "t2.xlarge": {
                 "SupportsNvme": "false"
+            },
+            "t3.large": {
+                "SupportsNvme": "true"
+            },
+            "t3.medium": {
+                "SupportsNvme": "true"
+            },
+            "t3.micro": {
+                "SupportsNvme": "true"
+            },
+            "t3.small": {
+                "SupportsNvme": "true"
+            },
+            "t3.xlarge": {
+                "SupportsNvme": "true"
             }
         }
     },
@@ -500,6 +565,12 @@
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Password of user (inside the Collibra console) with permissions to run backup jobs",
             "Type": "String"
         },
+        "CfnInitUrl": {
+            "AllowedPattern": "^http[s]?://.*$",
+            "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz",
+            "Description": "URL to the pip-installable aws-cfn-bootstrap package",
+            "Type": "String"
+        },
         "CloudWatchAgentUrl": {
             "AllowedPattern": "^$|^s3://.*$",
             "Default": "",
@@ -520,11 +591,12 @@
         },
         "CollibraDgcComponent": {
             "AllowedValues": [
-                "CONSOLE",
-                "JOBSERVER",
                 "AGENT",
-                "REPOSITORY",
+                "CONSOLE",
                 "DGC",
+                "JOBSERVER",
+                "MONITORING",
+                "REPOSITORY",
                 "SEARCH"
             ],
             "Description": "Which Collibra element to deploy",
@@ -570,14 +642,30 @@
                 "t2.medium",
                 "t2.large",
                 "t2.xlarge",
+                "t3.micro",
+                "t3.small",
+                "t3.medium",
+                "t3.large",
+                "t3.xlarge",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
                 "m4.xlarge",
                 "c5.large",
                 "c5.xlarge",
+                "c5.2xlarge",
+                "c5.4xlarge",
+                "c5.9xlarge",
                 "m5.large",
-                "m5.xlarge"
+                "m5.xlarge",
+                "m5.2xlarge",
+                "m5.4xlarge",
+                "m5.8xlarge",
+                "r5.large",
+                "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5.8xlarge"
             ],
             "Default": "t2.micro",
             "Description": "Amazon EC2 instance type",
@@ -678,10 +766,23 @@
             "CreationPolicy": {
                 "ResourceSignal": {
                     "Count": "1",
-                    "Timeout": "PT30M"
+                    "Timeout": "PT60M"
                 }
             },
             "Metadata": {
+                "AWS::CloudFormation::Authentication": {
+                    "S3AccessCreds": {
+                        "buckets": [
+                            {
+                                "Ref": "BackupBucket"
+                            }
+                        ],
+                        "roleName": {
+                            "Ref": "InstanceRoleName"
+                        },
+                        "type": "S3"
+                    }
+                },
                 "AWS::CloudFormation::Init": {
                     "admkey-install": {
                         "commands": {
@@ -748,7 +849,8 @@
                                 }
                             },
                             "02-relax-tmp": {
-                                "command": "mount -o remount,exec /tmp"
+                                "command": "mountpoint /tmp || true && mount -o remount,exec /tmp",
+                                "ignoreErrors": "true"
                             },
                             "03-relax-selinux": {
                                 "command": "setenforce 0"
@@ -953,7 +1055,25 @@
                                             {
                                                 "Fn::If": [
                                                     "IsJobServer",
-                                                    "    \"jobserverPort\": 4404,\n",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                "    \"jobserverDatabasePort\": 4414,\n",
+                                                                "    \"jobserverMonitoringPort\": 4424,\n",
+                                                                "    \"jobserverPort\": 4404,\n"
+                                                            ]
+                                                        ]
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "IsMonitoringServer",
+                                                    "    \"monitoringPort\": 4407,\n",
                                                     {
                                                         "Ref": "AWS::NoValue"
                                                     }
@@ -1114,18 +1234,25 @@
                             },
                             "02-install-jq": {
                                 "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "yum --enablerepo=",
-                                            {
-                                                "Ref": "EpelRepoName"
-                                            },
-                                            " install -y jq\n",
-                                            "\n"
-                                        ]
+                                    "Fn::If": [
+                                        "UseEpelRepo",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "yum install -y --enablerepo=",
+                                                    {
+                                                        "Ref": "EpelRepoName"
+                                                    },
+                                                    " jq\n",
+                                                    "\n"
+                                                ]
+                                            ]
+                                        },
+                                        "yum install -y jq\n"
                                     ]
-                                }
+                                },
+                                "ignoreErrors": "true"
                             }
                         },
                         "files": {
@@ -1173,40 +1300,28 @@
                                     "Fn::Join": [
                                         "",
                                         [
-                                            "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
+                                            "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.rpm &&",
                                             " aws s3 cp ",
                                             {
                                                 "Ref": "CloudWatchAgentUrl"
                                             },
-                                            " /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
+                                            " /etc/cfn/scripts/AmazonCloudWatchAgent.rpm"
                                         ]
                                     ]
                                 }
                             },
-                            "02-extract-cloudwatch-agent": {
+                            "02-install-cloudwatch-agent": {
                                 "command": {
                                     "Fn::Join": [
                                         "",
                                         [
-                                            "yum -y install unzip &&",
-                                            "unzip /etc/cfn/scripts/AmazonCloudWatchAgent.zip -d /etc/cfn/scripts/aws-cw-agent"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "10-install-cloudwatch-agent": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            " bash -xe install.sh &&",
+                                            "yum -y --nogpgcheck install /etc/cfn/scripts/AmazonCloudWatchAgent.rpm &&",
                                             " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
                                             " -a fetch-config -m ec2 -c",
                                             " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
                                         ]
                                     ]
-                                },
-                                "cwd": "/etc/cfn/scripts/aws-cw-agent"
+                                }
                             }
                         },
                         "files": {
@@ -1305,6 +1420,7 @@
                                                                             "Ref": "AppVolumeMountPath"
                                                                         },
                                                                         "/data/console/logs/console.log\",\n",
+                                                                        "      \"log_group_name\": \"",
                                                                         {
                                                                             "Ref": "CollibraLogGroup"
                                                                         },
@@ -1384,6 +1500,7 @@
                                                                 "Fn::Join": [
                                                                     "",
                                                                     [
+                                                                        "      {\n",
                                                                         "      \"file_path\": \"",
                                                                         {
                                                                             "Ref": "AppVolumeMountPath"
@@ -1498,23 +1615,6 @@
                                                 "Ref": "AWS::StackName"
                                             },
                                             " --resource CollibraHost",
-                                            {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --role ",
-                                                                {
-                                                                    "Ref": "InstanceRoleName"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
                                             {
                                                 "Fn::Join": [
                                                     "",
@@ -1673,23 +1773,6 @@
                                             },
                                             " --resource CollibraHost",
                                             {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --role ",
-                                                                {
-                                                                    "Ref": "InstanceRoleName"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
                                                 "Fn::Join": [
                                                     "",
                                                     [
@@ -1734,6 +1817,9 @@
                                             "\n",
                                             "# Upgrade pip and setuptools\n",
                                             "python3 -m pip install --index-url=\"$PYPI_URL\" --upgrade pip setuptools\n",
+                                            "\n",
+                                            "# Install boto3\n",
+                                            "python3 -m pip install --index-url=\"$PYPI_URL\" --upgrade boto3\n",
                                             "\n",
                                             "# Install watchmaker\n",
                                             "python3 -m pip install --index-url=\"$PYPI_URL\" --upgrade watchmaker\n"
@@ -1888,9 +1974,6 @@
                                         ]
                                     ]
                                 }
-                            },
-                            "15-salt-nofips": {
-                                "command": "salt-call --local ash.fips_disable"
                             }
                         }
                     },
@@ -2131,6 +2214,7 @@
                                     "Ref": "ProvisionUser"
                                 },
                                 "\n",
+                                "    selinux_user: unconfined_u\n",
                                 "users:\n",
                                 "  - default\n",
                                 "\n",
@@ -2200,10 +2284,47 @@
                                 {
                                     "Ref": "AWS::Region"
                                 },
+                                "\n",
+                                "export CFN_INIT_URL=",
+                                {
+                                    "Ref": "CfnInitUrl"
+                                },
+                                "\n",
                                 "\n\n",
-                                "printf \"%s\\t%s %s\\n\" ",
-                                "\"$( ip addr show eth0 | sed -n '/eth0$/p' | sed -e 's/^ *inet *//' -e 's#/.*$##' )\" ",
-                                "\"$( hostname -f)\" \"$( hostname -s )\" >> /etc/hosts\n",
+                                "# Which aws-cfn-bootstrap to use\n",
+                                "if [[ -n ${CFN_INIT_URL} ]]\n",
+                                "then\n",
+                                "   printf \"Pip-installing aws-cfn-bootstrap... \"\n",
+                                "   python3 -m pip install \"${CFN_INIT_URL}\"\n",
+                                "\n",
+                                "   if [[ $( python3 -m pip list | grep -w aws-cfn-bootstrap > /dev/null )$? -eq 0 ]]\n",
+                                "   then\n",
+                                "      echo \"Success!\"\n",
+                                "\n",
+                                "      if [[ ${PATH} == *\"/usr/local/bin\"* ]]\n",
+                                "      then\n",
+                                "         echo \"Already in PATH\"\n",
+                                "      else\n",
+                                "         echo \"Adding to PATH\"\n",
+                                "         export PATH=\"${PATH}:/usr/local/bin\"\n",
+                                "      fi\n",
+                                "      chmod 0755 /usr/local/init/redhat/cfn-hup\n",
+                                "\n",
+                                "      printf \"Creating startup-script... \"\n",
+                                "      ln -f -s /usr/local/init/redhat/cfn-hup /etc/rc.d/init.d/cfn-hup || \\\n",
+                                "        ( echo \"Failed!\" ; exit 1 )\n",
+                                "      chkconfig --add cfn-hup\n",
+                                "      chkconfig cfn-hup on\n",
+                                "   else\n",
+                                "      echo \"pip-install failed\"\n",
+                                "      exit 1\n",
+                                "   fi\n",
+                                "fi\n",
+                                "\n",
+                                "\n\n",
+                                "# Add hostname to /etc/hosts\n",
+                                "printf \"%s\t%s\\n\" \"$( hostname -I)\" \"$( hostname )\" >> /etc/hosts\n",
+                                "\n",
                                 "# Expand root and audit volume (40/60), based on any additional capacity available\n",
                                 "# If no addtional space allocated (> 20), command run w/o expanding\n",
                                 "# lvextedn command return code is ignored/masked below -- basically brute force\n",
@@ -2242,29 +2363,38 @@
                                 "python3 -m pip install",
                                 " --index-url=\"${PYPI_URL}\"",
                                 " --upgrade pyopenssl ndg-httpsclient pyasn1 'cryptography<2.2;python_version<\"2.7\"' 'cryptography;python_version>=\"2.7\"'",
+                                " boto3",
                                 "\n\n",
-                                "if [[ $( rpm --quiet -q aws-cfn-bootstrap )$? -ne 0 ]]\n",
+                                "# Which aws-cfn-bootstrap to use\n",
+                                "if [[ -n ${CFN_INIT_URL} ]]\n",
                                 "then\n",
-                                "   # Get cfn utils\n",
-                                "   yum install -y aws-cfn-bootstrap\n",
-                                "\n\n",
-                                "   # Fixup cfn utils\n",
-                                "   INITDIR=$( find -L /opt/aws/apitools/cfn-init/init -name redhat",
-                                " 2> /dev/null || echo /usr/init/redhat )\n",
-                                "   chmod 775 ${INITDIR}/cfn-hup\n",
-                                "   ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
-                                "   chkconfig --add cfn-hup\n",
-                                "   chkconfig cfn-hup on\n",
-                                "   mkdir -p /opt/aws/bin\n",
-                                "   BINDIR=$( find -L /opt/aws/apitools/cfn-init -name bin",
-                                " 2> /dev/null || echo /usr/bin )\n",
-                                "   for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup",
-                                " cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
-                                "   do\n",
-                                "      ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
-                                "      echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-                                "   done\n\n",
-                                "fi\n\n",
+                                "   printf \"Pip-installing aws-cfn-bootstrap... \"\n",
+                                "   python3 -m pip install \"${CFN_INIT_URL}\"\n",
+                                "\n",
+                                "   if [[ $( python3 -m pip list | grep -w aws-cfn-bootstrap > /dev/null )$? -eq 0 ]]\n",
+                                "   then\n",
+                                "      echo \"Success!\"\n",
+                                "\n",
+                                "      if [[ ${PATH} == *\"/usr/local/bin\"* ]]\n",
+                                "      then\n",
+                                "         echo \"Already in PATH\"\n",
+                                "      else\n",
+                                "         echo \"Adding to PATH\"\n",
+                                "         export PATH=\"${PATH}:/usr/local/bin\"\n",
+                                "      fi\n",
+                                "      chmod 0755 /usr/local/init/redhat/cfn-hup\n",
+                                "\n",
+                                "      printf \"Creating startup-script... \"\n",
+                                "      ln -f -s /usr/local/init/redhat/cfn-hup /etc/rc.d/init.d/cfn-hup || \\\n",
+                                "        ( echo \"Failed!\" ; exit 1 )\n",
+                                "      chkconfig --add cfn-hup\n",
+                                "      chkconfig cfn-hup on\n",
+                                "   else\n",
+                                "      echo \"pip-install failed\"\n",
+                                "      exit 1\n",
+                                "   fi\n",
+                                "fi\n",
+                                "\n",
                                 "# Remove gcc now that it is no longer needed\n",
                                 "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
                                 "# Add cfn utils to path\n",
@@ -2278,23 +2408,6 @@
                                     "Ref": "AWS::StackName"
                                 },
                                 " --resource CollibraHost",
-                                {
-                                    "Fn::If": [
-                                        "AssignInstanceRole",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    " --role ",
-                                                    {
-                                                        "Ref": "InstanceRoleName"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
                                 {
                                     "Fn::Join": [
                                         "",
@@ -2324,23 +2437,6 @@
                                 },
                                 "  --resource CollibraHost",
                                 {
-                                    "Fn::If": [
-                                        "AssignInstanceRole",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    " --role ",
-                                                    {
-                                                        "Ref": "InstanceRoleName"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                {
                                     "Fn::Join": [
                                         "",
                                         [
@@ -2363,6 +2459,9 @@
                                 ";",
                                 " exit 1",
                                 " )\n\n",
+                                "# Undo disblement of maintenance-user sudoers privs\n",
+                                "sed -i '/#.* NOPASSWD/s/^#//' $( find /etc -type f | xargs grep -l NOPASSWD )\n",
+                                "\n",
                                 "--===============3585321300151562773==--"
                             ]
                         ]


### PR DESCRIPTION
* Update for use with  newer Collibra versions and remove environment assumptions:
  * Add support for 'MONITORING' node-type
  * Update firewall ports opened for the Jobserver service
  * Remove disablement of FIPS mode

* Reduce assumptions about deployment environment:
  * Make name of epel repo optional (for environments where epel has
    been rolled-in to other channels)
  * Increase provisioning-timeout for environments where baked-in
    security-tools can markedly slow down the provisioning-process
  * Do not abort if /tmp isn't its own partition
  * Reduce specificity of CFn signaling-requests
  * Ensure boto3 is installed (for environments that do not already
    include it)
  * Ensure suitable selinux_user context is set (for environments where
    cloud-init's defaults are not properly configured)
  * Change computing/setting of hostname-mapping in /etc/hosts to
    something more-reliable

* Improve AWS deployability:
  * Add support for more m5.* instance-types
  * Add support for more c5.* instance-types
  * Add support for r5.* instance-types
  * Add support for fetching from non-public S3 repositories and objects
  * Allow use of S3-hosted source for CWA package
  * Update archive-extraction logic to account for way AWS now archives
    the agent

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists (note: there should probably never be no issue - see contribution guidelines)._
