### PR TITLE
Add ability to specify an EC2-customizer script

### DIFF
--- a/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
@@ -151,6 +151,30 @@
                 }
             ]
         },
+        "UseAmiFixer": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AmiLocalizerScript"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseBackupFolder": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "BackupFolder"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseComputerName": {
             "Fn::Not": [
                 {
@@ -499,6 +523,11 @@
         }
     },
     "Parameters": {
+        "AmiLocalizerScript": {
+            "AllowedPattern": "^$|^(http[s]?|s3)://.*$",
+            "Description": "Script to set EC2 to a 'known-good' starting-point",
+            "Type": "String"
+        },
         "AdminPubkeyURL": {
             "AllowedPattern": "^http[s]?://.*|^$",
             "Description": "(Optional) URL of file containing admin group's SSH public-keys",
@@ -2270,6 +2299,59 @@
                                 },
                                 "\n",
                                 "--===============3585321300151562773==\n",
+                                {
+                                    "Fn::If": [
+                                        "UseAmiFixer",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+                                                    "MIME-Version: 1.0\n",
+                                                    "Content-Transfer-Encoding: 7bit\n",
+                                                    "Content-Disposition: attachment; filename=\"ami_fix_script.sh\"\n",
+                                                    "\n",
+                                                    "#!/bin/bash -xe\n\n",
+                                                    "\n",
+                                                    "PATH=\"${PATH}\":/usr/local/bin\n",
+                                                    "export PATH\n",
+                                                    "\n",
+                                                    "if [[ ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " =~ \"http\"* ]]\n",
+                                                    "then\n",
+                                                    "   install -bDm 0750 <( curl -oL ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " ) /etc/cfn/scripts/ami_fixer\n",
+                                                    "elif [[ ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " =~ \"s3:\"* ]]\n",
+                                                    "then\n",
+                                                    "   install -bDm 0750 <( aws s3 cp ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " - ) /etc/cfn/scripts/ami_fixer\n",
+                                                    "fi\n",
+                                                    "\n",
+                                                    "/etc/cfn/scripts/ami_fixer\n",
+                                                    "\n",
+                                                    "--===============3585321300151562773==\n",
+                                                    "\n"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "AWS::NoValue"
+                                        }
+                                    ]
+                                },
                                 "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
                                 "MIME-Version: 1.0\n",
                                 "Content-Transfer-Encoding: 7bit\n",

--- a/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
@@ -523,11 +523,6 @@
         }
     },
     "Parameters": {
-        "AmiLocalizerScript": {
-            "AllowedPattern": "^$|^(http[s]?|s3)://.*$",
-            "Description": "Script to set EC2 to a 'known-good' starting-point",
-            "Type": "String"
-        },
         "AdminPubkeyURL": {
             "AllowedPattern": "^http[s]?://.*|^$",
             "Description": "(Optional) URL of file containing admin group's SSH public-keys",
@@ -537,6 +532,11 @@
             "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
             "Description": "ID of the AMI to launch",
             "Type": "AWS::EC2::Image::Id"
+        },
+        "AmiLocalizerScript": {
+            "AllowedPattern": "^$|^(http[s]?|s3)://.*$",
+            "Description": "Script to set EC2 to a 'known-good' starting-point",
+            "Type": "String"
         },
         "AppVolumeDevice": {
             "AllowedValues": [
@@ -575,6 +575,10 @@
         },
         "BackupBucket": {
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Name of the S3 bucket in which to store Collibra backups",
+            "Type": "String"
+        },
+        "BackupFolder": {
+            "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Name of the S3 bucket-key in which to store Collibra backups",
             "Type": "String"
         },
         "BackupSchedule": {
@@ -1303,11 +1307,28 @@
                                                 "Ref": "BackupUserPassword"
                                             },
                                             "\n",
-                                            "S3BUCKET=",
+                                            "S3BUCKET=\"",
                                             {
                                                 "Ref": "BackupBucket"
                                             },
-                                            "\n",
+                                            {
+                                                "Fn::If": [
+                                                    "UseBackupFolder",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                "/",
+                                                                {
+                                                                    "Ref": "BackupFolder"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            "\"\n",
                                             "\n",
                                             {
                                                 "Ref": "BackupSchedule"


### PR DESCRIPTION
Some AMIs may produce EC2s not in the state expected by the main-automation. This addition allows specifying a script that runs prior the main-automation, tweaking the launched EC2 as necessary for the main-automation to function properly.

Also adds the ability to point backups at a "folder" of an S3 bucket (for environments where creating a for-purpose S3 bucket is not possible).