### PR TITLE
Make a bit more flexible

### DIFF
--- a/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
@@ -163,6 +163,18 @@
                 }
             ]
         },
+        "UseBackupFolder": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "BackupFolder"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseComputerName": {
             "Fn::Not": [
                 {
@@ -563,6 +575,10 @@
         },
         "BackupBucket": {
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Name of the S3 bucket in which to store Collibra backups",
+            "Type": "String"
+        },
+        "BackupFolder": {
+            "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Name of the S3 bucket-key under which to store Collibra backups",
             "Type": "String"
         },
         "BackupSchedule": {
@@ -1291,11 +1307,28 @@
                                                 "Ref": "BackupUserPassword"
                                             },
                                             "\n",
-                                            "S3BUCKET=",
+                                            "S3BUCKET=\"",
                                             {
                                                 "Ref": "BackupBucket"
                                             },
-                                            "\n",
+                                            {
+                                                "Fn::If": [
+                                                    "UseBackupFolder",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                "/",
+                                                                {
+                                                                    "Ref": "BackupFolder"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            "\"\n",
                                             "\n",
                                             {
                                                 "Ref": "BackupSchedule"

--- a/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
@@ -427,6 +427,8 @@
                         "default": "Application Configuration"
                     },
                     "Parameters": [
+                        "AmiLocalizerScript",
+                        "CfnInitUrl",
                         "CollibraInstallerUrl",
                         "CollibraDgcComponent",
                         "CollibraSoftwareDir",
@@ -442,6 +444,7 @@
                     },
                     "Parameters": [
                         "BackupBucket",
+                        "BackupFolder",
                         "BackupSchedule",
                         "BackupScript",
                         "BackupUserName",
@@ -535,6 +538,7 @@
         },
         "AmiLocalizerScript": {
             "AllowedPattern": "^$|^(http[s]?|s3)://.*$",
+            "Default": "",
             "Description": "Script to set EC2 to a 'known-good' starting-point",
             "Type": "String"
         },
@@ -574,10 +578,12 @@
             "Type": "String"
         },
         "BackupBucket": {
+            "Default": "",
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Name of the S3 bucket in which to store Collibra backups",
             "Type": "String"
         },
         "BackupFolder": {
+            "Default": "",
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Name of the S3 bucket-key under which to store Collibra backups",
             "Type": "String"
         },
@@ -587,14 +593,17 @@
             "Type": "String"
         },
         "BackupScript": {
+            "Default": "",
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") S3-hosted location backup script",
             "Type": "String"
         },
         "BackupUserName": {
+            "Default": "",
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") User-name (inside the Collibra console) with permissions to run backup jobs",
             "Type": "String"
         },
         "BackupUserPassword": {
+            "Default": "",
             "Description": "(Optional: Only used if \"CollibraDgcComponent\" is set to \"CONSOLE\") Password of user (inside the Collibra console) with permissions to run backup jobs",
             "Type": "String"
         },

--- a/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
+++ b/Templates/make_collibra-dgc_EC2-standalone.tmplt.json
@@ -151,6 +151,18 @@
                 }
             ]
         },
+        "UseAmiFixer": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AmiLocalizerScript"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseComputerName": {
             "Fn::Not": [
                 {
@@ -508,6 +520,11 @@
             "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
             "Description": "ID of the AMI to launch",
             "Type": "AWS::EC2::Image::Id"
+        },
+        "AmiLocalizerScript": {
+            "AllowedPattern": "^$|^(http[s]?|s3)://.*$",
+            "Description": "Script to set EC2 to a 'known-good' starting-point",
+            "Type": "String"
         },
         "AppVolumeDevice": {
             "AllowedValues": [
@@ -2270,6 +2287,56 @@
                                 },
                                 "\n",
                                 "--===============3585321300151562773==\n",
+                                {
+                                    "Fn::If": [
+                                        "UseAmiFixer",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+                                                    "MIME-Version: 1.0\n",
+                                                    "Content-Transfer-Encoding: 7bit\n",
+                                                    "Content-Disposition: attachment; filename=\"ami_fix_script.sh\"\n",
+                                                    "\n",
+                                                    "#!/bin/bash -xe\n\n",
+                                                    "\n",
+                                                    "if [[ ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " =~ \"http\"* ]]\n",
+                                                    "then\n",
+                                                    "   install -bDm 0750 <( curl -OL ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " ) /etc/cfn/scripts/ami_fixer\n",
+                                                    "elif [[ ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " =~ \"s3:\"* ]]\n",
+                                                    "then\n",
+                                                    "   install -bDm 0750 <( aws s3 cp ",
+                                                    {
+                                                        "Ref": "AmiLocalizerScript"
+                                                    },
+                                                    " ) /etc/cfn/scripts/ami_fixer\n",
+                                                    "fi\n",
+                                                    "\n",
+                                                    "/etc/cfn/scripts/ami_fixer\n",
+                                                    "\n",
+                                                    "--===============3585321300151562773==\n",
+                                                    "\n"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "AWS::NoValue"
+                                        }
+                                    ]
+                                },
                                 "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
                                 "MIME-Version: 1.0\n",
                                 "Content-Transfer-Encoding: 7bit\n",


### PR DESCRIPTION
Add content to foster deployment-flexibility:

* Some environments restrict users to AMIs that may not meet expectations of main-automation. Allowing injection of a "fixer" script to be run ahead of the main-automation will expand the number of AMIs (and resultant EC2s) the main-automation can support.
* Some environments restrict users from creating dedicated S3 buckets for housing backups. This modification allows users to use a preconfigured or common-bucket by nesting all backups into an optional "folder"